### PR TITLE
Add support for ROM schema plugin

### DIFF
--- a/lib/rom/encrypted_attribute.rb
+++ b/lib/rom/encrypted_attribute.rb
@@ -4,11 +4,18 @@ require_relative "encrypted_attribute/key_derivator"
 require_relative "encrypted_attribute/decryptor"
 require_relative "encrypted_attribute/encryptor"
 require_relative "encrypted_attribute/version"
+require_relative "plugins/schema/encrypted_attributes"
 
 require "dry/types"
 
 module ROM
   module EncryptedAttribute
+    extend Dry::Configurable
+
+    setting :primary_key
+    setting :key_derivation_salt
+    setting :hash_digest_class, default: OpenSSL::Digest::SHA1
+
     def self.define_encrypted_attribute_types(primary_key:, key_derivation_salt:, hash_digest_class: OpenSSL::Digest::SHA1)
       key_derivator = KeyDerivator.new(salt: key_derivation_salt, secret: primary_key,
         hash_digest_class: hash_digest_class)

--- a/lib/rom/encrypted_attribute/version.rb
+++ b/lib/rom/encrypted_attribute/version.rb
@@ -2,6 +2,6 @@
 
 module ROM
   module EncryptedAttribute
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/lib/rom/plugins/schema/encrypted_attributes.rb
+++ b/lib/rom/plugins/schema/encrypted_attributes.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rom"
+
+module ROM
+  module Plugins
+    module Schema
+      module EncryptedAttributes
+        def self.apply(schema, **options)
+          attributes = options.fetch(:attributes)
+          primary_key = options.fetch(:primary_key, ROM::EncryptedAttribute.config.primary_key)
+          key_derivation_salt = options.fetch(:key_derivation_salt, ROM::EncryptedAttribute.config.key_derivation_salt)
+          hash_digest_class = options.fetch(:hash_digest_class, ROM::EncryptedAttribute.config.hash_digest_class)
+
+          encrypted_string, encrypted_string_reader =
+            ROM::EncryptedAttribute.define_encrypted_attribute_types(
+              primary_key: primary_key, key_derivation_salt: key_derivation_salt, hash_digest_class: hash_digest_class
+            )
+
+          attrs =
+            attributes.map do |name|
+              ROM::Schema::DSL.new(schema.name).build_attribute_info(
+                name,
+                encrypted_string,
+                name: name, read: encrypted_string_reader
+              )
+            end
+
+          schema.attributes.concat(
+            schema.class.attributes(attrs, schema.attr_class)
+          )
+        end
+
+        module DSL
+          # @example
+          #   schema do
+          #     use :encrypted_attributes
+          #     encrypt :api_key, :ssn, hash_digest_class: OpenSSL::Digest::SHA256
+          #   end
+          def encrypt(*attributes, **opts)
+            options = plugin_options(:encrypted_attributes)
+            options.merge!(opts)
+            options[:attributes] ||= []
+            options[:attributes] += attributes
+            self
+          end
+        end
+      end
+    end
+  end
+end
+
+ROM.plugins do
+  register :encrypted_attributes, ROM::Plugins::Schema::EncryptedAttributes, type: :schema
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,3 +21,8 @@ class CreateSecretNotes < ActiveRecord::Migration[7.0]
 end
 
 CreateSecretNotes.migrate :up
+
+ROM::EncryptedAttribute.configure do |config|
+  config.primary_key = TestData::PRIMARY_KEY
+  config.key_derivation_salt = TestData::KEY_DERIVATION_SALT
+end


### PR DESCRIPTION
### New API

``` ruby
ROM::EncryptedAttribute.configure do |config|
  config.primary_key = "your-primary-key" # required
  config.key_derivation_salt = "your-derivation-salt" # required
  config.hash_digest_class = OpenSSL::Digest::SHA256 # SHA1 by default
end
```

Then use the plugin in your ROM relation:

``` ruby
class SecretNotes < ::ROM::Relation[:sql]
  schema(:secret_notes, infer: true) do
    use :encrypted_attributes
    encrypt :content
  end
end
```

### Old API

Still available (called "bare metal")