### PR TITLE
Support NULL values

### DIFF
--- a/lib/rom/encrypted_attribute.rb
+++ b/lib/rom/encrypted_attribute.rb
@@ -12,6 +12,10 @@ module ROM
   module EncryptedAttribute
     extend Dry::Configurable
 
+    module Types
+      include Dry.Types()
+    end
+
     setting :primary_key
     setting :key_derivation_salt
     setting :hash_digest_class, default: OpenSSL::Digest::SHA1
@@ -20,11 +24,11 @@ module ROM
       key_derivator = KeyDerivator.new(salt: key_derivation_salt, secret: primary_key,
         hash_digest_class: hash_digest_class)
 
-      reader_type = Dry.Types.Constructor(String) do |value|
+      reader_type = Dry.Types.Constructor(Types::String.optional) do |value|
         ROM::EncryptedAttribute::Decryptor.new(derivator: key_derivator).decrypt(value)
       end
 
-      writer_type = Dry.Types.Constructor(String) do |value|
+      writer_type = Dry.Types.Constructor(Types::String.optional) do |value|
         ROM::EncryptedAttribute::Encryptor.new(derivator: key_derivator).encrypt(value)
       end
 

--- a/lib/rom/encrypted_attribute/decryptor.rb
+++ b/lib/rom/encrypted_attribute/decryptor.rb
@@ -12,6 +12,8 @@ module ROM
       end
 
       def decrypt(message)
+        return nil if message.nil?
+
         payload = ROM::EncryptedAttribute::Payload.decode(message)
 
         cipher = OpenSSL::Cipher.new("aes-256-gcm")

--- a/lib/rom/encrypted_attribute/encryptor.rb
+++ b/lib/rom/encrypted_attribute/encryptor.rb
@@ -13,6 +13,8 @@ module ROM
       end
 
       def encrypt(message)
+        return nil if message.nil?
+
         cipher = OpenSSL::Cipher.new("aes-256-gcm")
         key = @derivator.derive(cipher.key_len)
         iv = cipher.random_iv

--- a/test/test_rom_encrypted_attribute.rb
+++ b/test/test_rom_encrypted_attribute.rb
@@ -9,6 +9,12 @@ class TestEncryptedAttribute < Minitest::Test
     @repo = TestData::ROM::SecretNoteRepository.new(rom)
   end
 
+  def test_support_nulls
+    note = @repo.create(title: "test")
+    read_note = @repo.find(note.id)
+    assert_nil read_note.content
+  end
+
   def test_can_read_what_it_wrote
     note = @repo.create(title: "test", content: "test content")
     read_note = @repo.find(note.id)

--- a/test/test_rom_plugin.rb
+++ b/test/test_rom_plugin.rb
@@ -28,6 +28,12 @@ class TestRomPlugin < Minitest::Test
     @repo = SecretNoteRepository.new(rom)
   end
 
+  def test_support_nulls
+    note = @repo.create(title: "test")
+    read_note = @repo.find(note.id)
+    assert_nil read_note.content
+  end
+
   def test_can_read_what_it_wrote
     note = @repo.create(title: "test", content: "test content")
     read_note = @repo.find(note.id)


### PR DESCRIPTION
Somehow I missed the fact that values in the encrypted coolumns might be NULL. This adds support for this case.